### PR TITLE
On cluster, create base of the relative path if not present

### DIFF
--- a/StepClasses/lib/perl/MirrorToComputeCluster.pm
+++ b/StepClasses/lib/perl/MirrorToComputeCluster.pm
@@ -17,8 +17,10 @@ sub run {
 
   # $relativePath is a path relative to the workflow data dir on the local
   # server and also on the cluster.
-  # it must exist in its entirety.  $fileOrDir is the basename of the
-  # file to copy to that pre-existing path.
+  # Must exist locally.
+  # Will be created on the cluster if not present.
+  #
+  # $fileOrDir is the basename of the file to copy to that pre-existing path.
   my ($fileOrDir, $relativePath) = fileparse($fileOrDirToMirror);
 
   if($undo){
@@ -33,8 +35,10 @@ sub run {
       # therefore use runCmdOnClusterTransferServer instead of runCmdOnCluster
       $self->runCmdOnClusterTransferServer(0, "ls $clusterWorkflowDataDir/$fileOrDirToMirror");
       $self->runCmdOnClusterTransferServer(0, "rm -fr $clusterWorkflowDataDir/$fileOrDirToMirror");
+      $self->runCmdOnClusterTransferServer(0, "cd $clusterWorkflowDataDir && rmdir -p --ignore-fail-on-non-empty $relativePath");
   }else{
 
+      $self->runCmdOnClusterTransferServer(0, "cd $clusterWorkflowDataDir && mkdir -p $relativePath");
       $self->copyToCluster("$workflowDataDir/$relativePath",
 			   $fileOrDir,
 			   "$clusterWorkflowDataDir/$relativePath");


### PR DESCRIPTION
I have up to two cluster workflows for a dataset, sadly, for handling 16s and WGS data. I'm unable to split it into two datasets, because this dataset also corresponds to a card on the site, a file with sample details, etc. Because I'm not using ReFlow like I'm supposed to, it's a bit problematic, but I think I mostly have them solved.

The job ReFlow::StepClasses::MirrorToComputeCluster did not support copying to relative paths. This change creates the base relative to cluster workflow dir if not present, letting me have this structure:

```
./MicrobiomeStudy_${name}/16s_${name}/
./MicrobiomeStudy_${name}/WGS_${name}/
```

I think it's a sensible change overall but tell me if you think otherwise! Also I don't want to break people's jobs if it's somehow bad so I'd be grateful for a review.

Tested running and undoing with this change, on the Penn cluster.