### PR TITLE
Fix bug for git mode: both nextflow pull and nextflow run are within bsub. Allow retries

### DIFF
--- a/StepClasses/lib/perl/RunAndMonitorNextflow.pm
+++ b/StepClasses/lib/perl/RunAndMonitorNextflow.pm
@@ -89,15 +89,22 @@ sub runAndMonitor {
 	return 1 if $self->_checkClusterTaskLogForDone($logFile, $user, $transferServer);
 
 	my $nextflowCmd = "nextflow run $nextflowWorkflow -with-trace -c $clusterNextflowConfigFile -resume >$nextflowStdoutFile 2>&1";
+        if($isGit){
+          $nextflowCmd = "nextflow pull $nextflowWorkflow; $nextflowCmd";
+        }
 
-        my $fullCommand = $isGit ? "nextflow pull $nextflowWorkflow; $nextflowCmd" : $nextflowCmd;
+        # prepend slash to ;, >, and & so that the command is submitted whole
+        $nextflowCmd =~ s{([;>&])}{\\$1}g;
 
-	my $submitCmd = $self->getNodeClass()->getQueueSubmitCommand($queue, $fullCommand);
+	my $submitCmd = $self->getNodeClass()->getQueueSubmitCommand($queue, $nextflowCmd);
 
+
+        # wrap in a login shell to allow nextflow to be user installed
 	my $cmd = "cd $workingDir; $submitCmd ";
+        $cmd = "/bin/bash -login -c \"$cmd\"";
 
 	# do the submit on submit server, and capture its output
-        my $jobInfo = $self->_runSshCmdWithRetries(0, "/bin/bash -login -c \"$cmd\"", "", 1, 0, $user, $submitServer, "");
+        my $jobInfo = $self->_runSshCmdWithRetries(0, $cmd, "", 1, 0, $user, $submitServer, "");
 
 	$self->error("Did not get jobInfo back from command:\n $cmd") unless $jobInfo;
 


### PR DESCRIPTION
Before the command was:
```
ssh -2 wbazant@consign.pmacs.upenn.edu '/bin/bash -login -c "cd /project/eupathdblab/workflows/MicrobiomeDB/5/data/otuDADA2_ENTiCE_RSRC/Humann_ENTiCE; bsub -q normal    nextflow pull wbazant
/humann-nextflow; nextflow run wbazant/humann-nextflow -with-trace -c /project/eupathdblab/workflows/MicrobiomeDB/5/data/otuDADA2_ENTiCE_RSRC/Humann_ENTiCE/nextflow.config -resume >/project/
eupathdblab/workflows/MicrobiomeDB/5/data/otuDADA2_ENTiCE_RSRC/Humann_ENTiCE/nextflow.txt 2>&1 "'
```

The nextflow.txt file had a boring "Submitted job id 1234" and ` nextflow run ` happened on consign.

With this change, it's

```
ssh -2 wbazant@consign.pmacs.upenn.edu '/bin/bash -login -c "cd /project/eupathdblab/workflows/MicrobiomeDB/5/data/otuDADA2_ENTiCE_RSRC/Humann_ENTiCE\; bsub -q normal    nextflow pull wbazant/humann-nextflow\; nextflow run wbazant/humann-nextflow -with-trace -c /project/eupathdblab/workflows/MicrobiomeDB/5/data/otuDADA2_ENTiCE_RSRC/Humann_ENTiCE/nextflow.config -resume \>/project/eupathdblab/workflows/MicrobiomeDB/5/data/otuDADA2_ENTiCE_RSRC/Humann_ENTiCE/nextflow.txt 2\>\&1 "'
```

which still loses the logs from pulling but it's better.

