### PR TITLE
Force dbName to lowercase.

### DIFF
--- a/StepClasses/lib/perl/MakeDatabase.pm
+++ b/StepClasses/lib/perl/MakeDatabase.pm
@@ -19,15 +19,18 @@ sub run {
   # which is useful for global dbs etc.s
   $dbName .= "_" . $self->getParamValue('dbName') if $self->getParamValue('dbName');
 
+  # Convert dbName to lowercase.
+  $dbName = lc ($dbName);
+
   my $roleSql = "SET ROLE gus_w";
   my $currentDbSql = "SELECT current_database()";
 
   if($undo){
-    my $sql = "DROP DATABASE \"$dbName\"";
+    my $sql = "DROP DATABASE $dbName";
     $self->{workflow}->_runSql($roleSql);
     $self->{workflow}->_runSql($sql);
   }else{
-      my $sql = "CREATE DATABASE \"$dbName\" WITH TEMPLATE template_gus_apidb";
+      my $sql = "CREATE DATABASE $dbName WITH TEMPLATE template_gus_apidb";
     if($test) {
       $self->log("will create database with script $sql");
     }

--- a/StepClasses/lib/perl/MakeGusConfig.pm
+++ b/StepClasses/lib/perl/MakeGusConfig.pm
@@ -16,6 +16,8 @@ sub run {
   # which is useful for global dbs etc.
   $dbName .= "_" . $self->getParamValue('dbName') if $self->getParamValue('dbName');
 
+  # Convert dbName to lowercase.
+  $dbName = lc ($dbName);
 
   my $dataDir = $self->getParamValue("dataDir") ? $self->getParamValue('dataDir') : ".";
   my $gusConfigFilename = $self->getParamValue('gusConfigFilename');


### PR DESCRIPTION
We don't want to have mixed case database names. So convert it to lowercase. We originally thought this would be a nice perk for readability with orgSpecific databases but it's no longer applicable. Instead we want to keep it consistent with everything else.